### PR TITLE
Simple Jupyter Notebook to be used in NOMAD distro

### DIFF
--- a/.github/workflows/publish_north.yml
+++ b/.github/workflows/publish_north.yml
@@ -57,7 +57,7 @@ jobs:
           # https://github.com/docker/metadata-action?tab=readme-ov-file#image-name-and-tag-sanitization
           tags: |
             type=ref,event=tag
-            type=ref,event=pr,prefix={{branch}}-
+            type=ref,event=pr,prefix=pr-
             type=raw,value=main,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
           flavor: |
             latest=auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,12 @@ dev = [
     "pytest-asyncio",
 ]
 
+[dependency-groups]
+north = [
+    "jupyterlab",
+    "ipywidgets",
+]
+
 [tool.uv]
 extra-index-url = [
   "https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple",

--- a/src/nomad_north_jupyter/north_tools/my_north_tool/Dockerfile
+++ b/src/nomad_north_jupyter/north_tools/my_north_tool/Dockerfile
@@ -1,6 +1,7 @@
 ARG JUPYTER_TAG=2025-12-31
 ARG BASE_JUPYTER=quay.io/jupyter/base-notebook
 ARG UV_VERSION=0.9
+ARG PLUGIN_NAME="nomad-north-jupyter"
 
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_stage
 
@@ -17,6 +18,8 @@ USER root
 # With pre-existing NB_USER="jovyan" and NB_UID=100, NB_GID=1000
 ENV HOME=/home/${NB_USER}
 ENV CONDA_DIR=/opt/conda
+
+ARG PLUGIN_NAME
 
 RUN apt-get update \
  && apt-get install --yes --quiet --no-install-recommends \
@@ -50,9 +53,24 @@ ENV UV_PROJECT_ENVIRONMENT=${CONDA_DIR} \
     # If needed one can create another venv with 'uv venv'
     UV_SYSTEM_PYTHON=1
 
+COPY --chown=${NB_USER}:${NB_GID} . ${HOME}/${PLUGIN_NAME}
+
+WORKDIR ${HOME}/${PLUGIN_NAME}
+
+# https://docs.astral.sh/uv/guides/integration/docker/#intermediate-layers
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install . --group north
+
+
+WORKDIR ${HOME}
+RUN rm -rf ${HOME}/${PLUGIN_NAME}
+
 RUN jupyter lab build --dev-build=False --minimize=False && \
     fix-permissions "/home/${NB_USER}" \
     && fix-permissions "${CONDA_DIR}"
+
+WORKDIR ${HOME}
 
 EXPOSE 8888
 

--- a/src/nomad_north_jupyter/north_tools/my_north_tool/README.md
+++ b/src/nomad_north_jupyter/north_tools/my_north_tool/README.md
@@ -32,4 +32,3 @@ For comprehensive documentation on creating and managing NORTH tools, including 
 - Dependency management
 
 See the [NOMAD NORTH Tools documentation](https://fairmat-nfdi.github.io/nomad-docs/howto/plugins/types/north_tools.html).
-


### PR DESCRIPTION
The plugin `nomad-north-jupyter` will be used in nomad-distro by default. Therefore, the Jupyter image can be used using the NORTH tool plugin entry-point. See the following discussion from the plugin meeting

**NORTH (Plugin Meeting Discussion)**

- FAIRmat will host a “default” plugin called `nomad-north-jupyter` where we provide a Jupyter NorthToolEntryPoint that also has a default image
- In the distro-template:
    - We keep the way we are currently building the image (i.e., in the Dockerfile, everything starting from [https://github.com/FAIRmat-NFDI/nomad-distro-template/blob/4d890950c0df70d741a7bbedc39bcff7869553c3/Dockerfile#L166](https://github.com/FAIRmat-NFDI/nomad-distro-template/blob/4d890950c0df70d741a7bbedc39bcff7869553c3/Dockerfile#L166))
    - Here, by default, we install the `nomad-north-jupyter` plugin and in the provided nomad.yaml, we overwrite the NORTH tool image with the image built in the distro: [https://github.com/FAIRmat-NFDI/nomad-distro-template/blob/main/configs/nomad.yaml#L9](https://github.com/FAIRmat-NFDI/nomad-distro-template/blob/main/configs/nomad.yaml#L9)
    - Similarly in the central deployments
- In the cookiecutter-template ( https://github.com/FAIRmat-NFDI/cookiecutter-nomad-plugin), we provide a bare-bones Dockerfile where we tell which base images you can use and where you can find example Dockerfiles.

